### PR TITLE
Accept varargs in keyboard-press

### DIFF
--- a/src/wally/main.clj
+++ b/src/wally/main.clj
@@ -339,13 +339,13 @@
   (.url (get-page)))
 
 (defn keyboard-press
-  "Press keyboard.
+  "Press keyboard. If multiple args passed, keys pressed is succession.
 
   See https://playwright.dev/docs/api/class-keyboard.
 
   E.g. `(keyboard-press \"Enter\")`"
-  [key]
-  (.. (get-page) keyboard (press key)))
+  [& keys]
+  (run! (fn [key] (.. (get-page) keyboard (press key))) keys))
 
 (comment
 


### PR DESCRIPTION
Just a tiny thing. Found it useful in editor tests at work. Updated the docstring to avoid confusion with key combinations. Could be also a separate function `keyboard-presses` if you prefer.