### PR TITLE
Use nested vectors for logical conjunction (and)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -7,6 +7,9 @@
 
  :aliases {:build {:deps {io.github.seancorfield/build-clj
                           {:git/tag "v0.9.2" :git/sha "9c9f078"}}
-                   :ns-default build}}
+                   :ns-default build}
+           :test {:extra-paths ["test"]
+                  :extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}}
+                  :main-opts ["-m" "kaocha.runner"]}}
 
  :paths ["src"]}

--- a/src/wally/main.clj
+++ b/src/wally/main.clj
@@ -133,6 +133,13 @@
     (instance? CSSSelector q)
     (s/css-selector q)
 
+    (and (sequential? q)
+         (sequential? (first q))
+         (= (count q) 1))
+    ;; Nested vector/list represents a logical conjunction (and).
+    (->> (map query->selector (first q))
+         (str/join))
+
     (sequential? q)
     ;; Chain comands if query is a list or a vector.
     (->> (mapv query->selector q)

--- a/test/wally/main_test.clj
+++ b/test/wally/main_test.clj
@@ -1,7 +1,8 @@
 (ns wally.main-test
   (:require [clojure.test :refer [are deftest]]
             [garden.selectors :as s]
-            [wally.main :as w]))
+            [wally.main :as w]
+            [wally.selectors :as ws]))
 
 (deftest query->selector
   (are [q expected] (= expected (w/query->selector q))
@@ -10,4 +11,6 @@
     :.bar ".bar"
     "baz" "baz"
     [:#foo :.bar "baz"] "#foo >> .bar >> baz"
-    (list "x" "y") "x >> y"))
+    (list "x" "y") "x >> y"
+    [[:.foo (ws/text "bar")]] ".foo:text(\"bar\")"
+    (list (list :.x :.y)) ".x.y"))

--- a/test/wally/main_test.clj
+++ b/test/wally/main_test.clj
@@ -1,0 +1,13 @@
+(ns wally.main-test
+  (:require [clojure.test :refer [are deftest]]
+            [garden.selectors :as s]
+            [wally.main :as w]))
+
+(deftest query->selector
+  (are [q expected] (= expected (w/query->selector q))
+    (s/attr "href") "[href]"
+    :#foo "#foo"
+    :.bar ".bar"
+    "baz" "baz"
+    [:#foo :.bar "baz"] "#foo >> .bar >> baz"
+    (list "x" "y") "x >> y"))


### PR DESCRIPTION
There must be a more elegant way of doing this in Garden already but this is just an extension to Wally's selector syntax for a shortcut.

    [:.foo (ws/text "bar")]    =>  .foo >> :text("bar")  ; No change there.
    [[:.foo (ws/text "bar")]]  =>  .foo:text("bar")

This is on top of https://github.com/pfeodrippe/wally/pull/9 which would need to go in first.