### PR TITLE
Fix clojure version and windows

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:deps
- {org.clojure/clojure {:mvn/version "1.11.1"}
+ {org.clojure/clojure {:mvn/version "1.12.1"}
   camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
   garden/garden {:mvn/version "1.3.10"}
   com.microsoft.playwright/playwright {:mvn/version "1.50.0"}

--- a/src/wally/main.clj
+++ b/src/wally/main.clj
@@ -44,8 +44,7 @@
        ;; so we can login to Google (e.g. for QA develop
        ;; admin) only once during days.
        (Paths/get (java.net.URI.
-                   (str "file://"
-                        (.getAbsolutePath user-data-dir))))
+                    (str (.toURI user-data-dir))))
        (-> (BrowserType$LaunchPersistentContextOptions.)
            (.setHeadless headless)
            (.setSlowMo 50)))


### PR DESCRIPTION
I wanted to try out this library but stumbled upon two issues:

# ClassCastException in clojure 1.11.1

Trying to start a browser with clojure 1.11.1 fails with:
```
Execution error (ClassCastException) at java.lang.Class/cast (Class.java:4067).
Cannot cast wally.main$make_page$fn__2605$fn__2609 to java.util.function.Consumer
```
when trying to set a function as `.onClose` handler.
Using clojure 1.12.1 as dependency fixes this

# Error when using on windows

Using `(java.net.URI. (str "file://" (.getAbsolutePath user-data-dir))` fails on windows because it results in a `"file://C:\\User\\...."` which is not a valid uri.
As `user-data-dir` already is an `java.io.File` we can use `(.toURI user-data-dir)` which should be os independent.